### PR TITLE
cleanup: don't check cliConfig to determine setup state

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ class SupervisorExtension extends cli.Extension {
 
     let fileBaseName = `${ctx.instance.name}`;
 
-    if (ctx.instance.cliConfig.get('extension.supervisor', false) || fs.existsSync(path.join('/etc/supervisor/conf.d', `${fileBaseName}.conf`))) {
+    if (fs.existsSync(path.join('/etc/supervisor/conf.d', `${fileBaseName}.conf`))) {
       this.ui.log('Supervisor has already been set up. Skipping Supervisor setup');
       return task.skip();
     }


### PR DESCRIPTION
no issue
- in the systemd built-in CLI extension, this particular check was only added for backwards-compatibility, meaning it's not needed here as it's a new extension