### PR TITLE
Fixes ctx.instance.template error in ghost-cli 1.9.8

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ class SupervisorExtension extends cli.Extension {
 
         const service = template(fs.readFileSync(path.join(__dirname, 'ghost.supervisor.template'), 'utf8'));
 
-        return ctx.instance.template(service({
+        return this.template(service({
             name: fileBaseName,
             dir: process.cwd(),
             user: 'ghost',

--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ class SupervisorExtension extends cli.Extension {
             ghost_exec_path: process.argv.slice(0,2).join(' ')
         });
 
-        return this.template(instance, contents, 'supervisor config', `${fileBaseName}.conf`, '/etc/supervisor/conf.d').then(
+        return this.template(ctx.instance, contents, 'supervisor config', `${fileBaseName}.conf`, '/etc/supervisor/conf.d').then(
             () => this.ui.sudo('supervisorctl update')
         );
     }

--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ class SupervisorExtension extends cli.Extension {
         const contents = service({
             name: fileBaseName,
             dir: process.cwd(),
-            user: uid,
+            user: 'ghost',
             environment: this.system.environment,
             ghost_exec_path: process.argv.slice(0,2).join(' ')
         });

--- a/index.js
+++ b/index.js
@@ -32,14 +32,15 @@ class SupervisorExtension extends cli.Extension {
         }
 
         const service = template(fs.readFileSync(path.join(__dirname, 'ghost.supervisor.template'), 'utf8'));
-
-        return this.template(service({
+        const contents = service({
             name: fileBaseName,
             dir: process.cwd(),
-            user: 'ghost',
+            user: uid,
             environment: this.system.environment,
             ghost_exec_path: process.argv.slice(0,2).join(' ')
-        }), 'supervisor config', `${fileBaseName}.conf`, '/etc/supervisor/conf.d').then(
+        });
+
+        return this.template(instance, contents, 'supervisor config', `${fileBaseName}.conf`, '/etc/supervisor/conf.d').then(
             () => this.ui.sudo('supervisorctl update')
         );
     }


### PR DESCRIPTION
I came across an error while creating a new instance of ghost with supervisor the error was `ctx.instance.template is not a function` Looking through the code it was quite a simple fix just looks like they changed a few things with ghost-cli I have used my version and it seems to work as expected.